### PR TITLE
Minor spelling inconsistency fix

### DIFF
--- a/locationgroups/wcw.json
+++ b/locationgroups/wcw.json
@@ -1,7 +1,7 @@
 {
     "titles": {
         "de": "WC f\u00fcr Frauen",
-        "en": "WC for Women"
+        "en": "WC for women"
     },
     "can_search": true,
     "can_describe": false,


### PR DESCRIPTION
"men" and "women only" is written in lowercase, too